### PR TITLE
Updated deploy instructions and change Cleanup() and InitilizePhase2() to virtual members

### DIFF
--- a/model/core/src/ExtensionMain.cs
+++ b/model/core/src/ExtensionMain.cs
@@ -110,14 +110,14 @@ namespace Landis.Core
 
         //---------------------------------------------------------------------
 
-        public void InitializePhase2()
+        public virtual void InitializePhase2()
         {
             // No-op !!!
         }
 
         //---------------------------------------------------------------------
 
-        public void CleanUp()
+        public virtual void CleanUp()
         {
             // No-op !!!
         }

--- a/model/core/src/Implementation/main/Model.cs
+++ b/model/core/src/Implementation/main/Model.cs
@@ -321,6 +321,7 @@ namespace Landis
                 ui.WriteLine("Loading {0} extension ...", scenario.Succession.Info.Name);
                 succession = Loader.Load<SuccessionMain>(scenario.Succession.Info);
                 succession.LoadParameters(scenario.Succession.InitFile, this);
+                // look here for succession initialization VINCENT
                 succession.Initialize();
 
                 ExtensionMain[] disturbanceExtensions = LoadExtensions(scenario.Disturbances);

--- a/model/deploy/README.txt
+++ b/model/deploy/README.txt
@@ -15,6 +15,13 @@ where (#) is an integer = or > 1.  For example:
     beta release 2
     release candidate 1
 
+NOTE FOR DEBUG MODE: in App.cs 3 lines must be uncommented. Search for this string "Pre-pending the GDAL directory is required to run the Console project in debug mode" and uncomment out the following 3 lines before building in Visual Studio:
+
+                // string path = Environment.GetEnvironmentVariable("PATH");
+                // string newPath = "C:\\Program Files\\LANDIS-II\\GDAL\\1.9;" + path;
+                // Environment.SetEnvironmentVariable("PATH", newPath);
+
+
 
 Staging a Configuration For Testing
 -----------------------------------
@@ -39,18 +46,21 @@ the ../build/install/Debug/ directory.
 
 3. install extensions
 ---------------------
-For general testing you can either build each extension seperatly from its respective repo and place contents in
-some/path/to/model/build/install/debug/v6 
+For general testing you can either build each extension seperatley from its respective repo and place contents in
+  
+  some/path/to/model/build/install/debug/v6 
 
 OR
 --
 
 Download extensions from www.landis-ii.org and copy contents of installed files 
-FROM path/to/LANDIS-II/v6 TO some/path/to/model/build/install/debug/v6 
+  FROM:   path/to/LANDIS-II/v6 
+  TO:     some/path/to/model/build/install/debug/v6 
 
 4. Running staged configuration
 -------------------------------
 This configuration of LANDIS-II can
 be run by using the scripts in the installation's bin/ directory:
+
   cd some/path/to/test/scenarios
   path_to_model_project/build/install/Debug/bin/landis-ii scenario_1.txt


### PR DESCRIPTION
This change needs to be made in tandem with commits from
Extension-Base-BDA, Extension-LinearWind, Extension-Land-Use-Change, and Core-Model.